### PR TITLE
Resolve conflict example-cli -k option

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -30,7 +30,7 @@ func ContractCallCommand() *cobra.Command {
 	pflags.StringVarP(&txFlags.ReadURI, "read", "r", "http://localhost:46658/query", "URI for quering app state")
 	pflags.StringVarP(&txFlags.ContractAddr, "contract", "", "", "contract address")
 	pflags.StringVarP(&txFlags.ChainID, "chain", "", "default", "chain ID")
-	pflags.StringVarP(&txFlags.PrivFile, "key", "k", "", "private key file")
+	pflags.StringVarP(&txFlags.PrivFile, "private-key", "p", "", "private key file")
 	return cmd
 }
 

--- a/examples/cli/cli.go
+++ b/examples/cli/cli.go
@@ -14,7 +14,7 @@ var writeURI, readURI, chainID string
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "cli",
+		Use:   "example-cli",
 		Short: "CLI example",
 	}
 	callCmd := cli.ContractCallCommand()


### PR DESCRIPTION
-k option not found in Flags section because of conflict -k option in Global Flags Section.

```
$ ./example-cli call set_msg --help
Calls the SetMsg method of the helloworld contract

Usage:
  cli call set_msg [flags]

Flags:
  -h, --help           help for set_msg
  -v, --value string   value to associate with the key

Global Flags:
      --chain string      chain ID (default "default")
      --contract string   contract address
  -k, --key string        private key file
  -r, --read string       URI for quering app state (default "http://localhost:46658/query")
  -w, --write string      URI for sending txs (default "http://localhost:46658/rpc")
```

Change Global Flags `-k` option to `-p` or `--private-key` .

```
$ ./example-cli call set_msg --help
Calls the SetMsg method of the helloworld contract

Usage:
  example-cli call set_msg [flags]

Flags:
  -h, --help           help for set_msg
  -k, --key string
  -v, --value string   value to associate with the key

Global Flags:
      --chain string         chain ID (default "default")
      --contract string      contract address
  -p, --private-key string   private key file
  -r, --read string          URI for quering app state (default "http://localhost:46658/query")
  -w, --write string         URI for sending txs (default "http://localhost:46658/rpc")
```