### PR TITLE
Add go-solidity-sha3 to deps

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,8 @@ ignored = [
   "github.com/spf13/cobra*",
   "github.com/spf13/pflag*",
   "github.com/ethereum/go-ethereum*",
-  "github.com/go-kit/kit*"
+  "github.com/go-kit/kit*",
+  "github.com/miguelmota/go-solidity-sha3*"
 ]
 
 [[constraint]]

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ deps:
 		github.com/hashicorp/go-plugin \
 		github.com/stretchr/testify/assert \
 		github.com/go-kit/kit/log \
-		github.com/pkg/errors
+		github.com/pkg/errors \
+		github.com/miguelmota/go-solidity-sha3
 	dep ensure -vendor-only
 	cd $(GOGO_PROTOBUF_DIR) && git checkout 1ef32a8b9fc3f8ec940126907cedb5998f6318e4
 

--- a/common/evmcompat/helpers.go
+++ b/common/evmcompat/helpers.go
@@ -33,6 +33,9 @@ func SoliditySign(data []byte, privKey *ecdsa.PrivateKey) ([]byte, error) {
 
 // SolidityRecover recovers the Ethereum address from the signed hash and the 65-byte signature.
 func SolidityRecover(hash []byte, sig []byte) (common.Address, error) {
+	if len(sig) != 65 {
+		return common.Address{}, fmt.Errorf("signature must be 65 bytes, got %d bytes", len(sig))
+	}
 	stdSig := make([]byte, 65)
 	copy(stdSig[:], sig[:])
 	stdSig[len(sig)-1] -= 27
@@ -53,6 +56,7 @@ type Pair struct {
 	Value string
 }
 
+// NOTE: This function is deprecated, use the one in github.com/miguelmota/go-solidity-sha3 instead!
 func SoliditySHA3(pairs []*Pair) ([]byte, error) {
 	//convert to packed bytes like solidity
 	data, err := SolidityPackedBytes(pairs)


### PR DESCRIPTION
This lib is used for packing data sent to Solidity, it produces the same byte encoding as abi.encodePacked() does in Solidity. We already have a function to do this but this lib has a nicer API than what we have and supports more types.