### PR TITLE
Support ERC20 and ETH Coins in Plasma Cash

### DIFF
--- a/client/plasma_cash/block.go
+++ b/client/plasma_cash/block.go
@@ -41,14 +41,14 @@ func (p *PbBlock) TxFromSlot(slot uint64) (Tx, error) {
 
 	prevBlock := big.NewInt(0)
 	if tx.GetPreviousBlock() != nil {
-		prevBlock = big.NewInt(tx.GetPreviousBlock().Value.Int64()) //TODO cleanup this casting
+		prevBlock = tx.GetPreviousBlock().Value.Int
 	}
 	address := tx.NewOwner.Local.String()
 	ethAddress := common.HexToAddress(address)
 
 	return &LoomTx{Slot: slot,
 		PrevBlock:    prevBlock,
-		Denomination: uint32(tx.Denomination.Value.Uint64()), //TODO First iteration is for ERC721 so this is always 1
+		Denomination: tx.Denomination.Value.Int,
 		Owner:        ethAddress,
 		Signature:    tx.Signature,
 		TXProof:      tx.Proof}, nil

--- a/client/plasma_cash/encoding_test.go
+++ b/client/plasma_cash/encoding_test.go
@@ -28,7 +28,7 @@ func (s *EncodingTestSuite) TestUnsignedTxRlpEncode(c *C) {
 	tx := &LoomTx{
 		Slot:         5,
 		PrevBlock:    big.NewInt(0),
-		Denomination: 1,
+		Denomination: big.NewInt(1),
 		Owner:        ownerAddr,
 	}
 	txBytes, err := tx.RlpEncode()
@@ -56,7 +56,7 @@ func (s *EncodingTestSuite) TestTxHash(c *C) {
 	tx := &LoomTx{
 		Slot:         5,
 		PrevBlock:    big.NewInt(85478557858583),
-		Denomination: 1,
+		Denomination: big.NewInt(1),
 		Owner:        ownerAddr,
 	}
 	hexStr := common.Bytes2Hex(tx.Hash())
@@ -72,7 +72,7 @@ func (s *EncodingTestSuite) TestTxSignature(c *C) {
 	tx := &LoomTx{
 		Slot:         5,
 		PrevBlock:    big.NewInt(85478557858583),
-		Denomination: 1,
+		Denomination: big.NewInt(1),
 		Owner:        ownerAddr,
 	}
 	sig, err := tx.Sign(privKey)
@@ -97,7 +97,7 @@ func (s *EncodingTestSuite) TestUnsignedTxRlpEncode2(c *C) {
 	tx := &LoomTx{
 		Slot:         2,
 		PrevBlock:    big.NewInt(1000),
-		Denomination: 1,
+		Denomination: big.NewInt(1),
 		Owner:        ownerAddr,
 	}
 	txBytes, err := tx.RlpEncode()

--- a/client/plasma_cash/eth/ethcontract/root_chain.go
+++ b/client/plasma_cash/eth/ethcontract/root_chain.go
@@ -16,7 +16,7 @@ import (
 )
 
 // RootChainABI is the input ABI used to generate the binding from.
-const RootChainABI = "[{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"balances\",\"outputs\":[{\"name\":\"bonded\",\"type\":\"uint256\"},{\"name\":\"withdrawable\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"childBlockInterval\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"numCoins\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"exitSlots\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"currentBlock\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"childChain\",\"outputs\":[{\"name\":\"root\",\"type\":\"bytes32\"},{\"name\":\"createdAt\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_vmc\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"denomination\",\"type\":\"uint64\"},{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"contractAddress\",\"type\":\"address\"}],\"name\":\"Deposit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"root\",\"type\":\"bytes32\"},{\"indexed\":false,\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SubmittedBlock\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":true,\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"StartedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"txHash\",\"type\":\"bytes32\"}],\"name\":\"ChallengedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"RespondedExitChallenge\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"FinalizedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"FreedBond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"SlashedBond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"WithdrewBonds\",\"type\":\"event\"},{\"constant\":false,\"inputs\":[{\"name\":\"root\",\"type\":\"bytes32\"}],\"name\":\"submitBlock\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"prevTxBytes\",\"type\":\"bytes\"},{\"name\":\"exitingTxBytes\",\"type\":\"bytes\"},{\"name\":\"prevTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"exitingTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"},{\"name\":\"blocks\",\"type\":\"uint256[2]\"}],\"name\":\"startExit\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"finalizeExit\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"finalizeExits\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"withdraw\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"prevTxBytes\",\"type\":\"bytes\"},{\"name\":\"txBytes\",\"type\":\"bytes\"},{\"name\":\"prevTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"txInclusionProof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"},{\"name\":\"blocks\",\"type\":\"uint256[2]\"}],\"name\":\"challengeBefore\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingTxHash\",\"type\":\"bytes32\"},{\"name\":\"respondingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"respondingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"respondChallengeBefore\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"challengingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"challengeBetween\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"challengingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"challengeAfter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"withdrawBonds\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_from\",\"type\":\"address\"},{\"name\":\"_uid\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC721Received\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes4\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"txHash\",\"type\":\"bytes32\"},{\"name\":\"root\",\"type\":\"bytes32\"},{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"checkMembership\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"getPlasmaCoin\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint32\"},{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"getExit\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getBlockRoot\",\"outputs\":[{\"name\":\"root\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const RootChainABI = "[{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"balances\",\"outputs\":[{\"name\":\"bonded\",\"type\":\"uint256\"},{\"name\":\"withdrawable\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"childBlockInterval\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"numCoins\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"exitSlots\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"currentBlock\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"childChain\",\"outputs\":[{\"name\":\"root\",\"type\":\"bytes32\"},{\"name\":\"createdAt\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_vmc\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"denomination\",\"type\":\"uint256\"},{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"contractAddress\",\"type\":\"address\"}],\"name\":\"Deposit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"root\",\"type\":\"bytes32\"},{\"indexed\":false,\"name\":\"timestamp\",\"type\":\"uint256\"}],\"name\":\"SubmittedBlock\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":true,\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"StartedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"txHash\",\"type\":\"bytes32\"}],\"name\":\"ChallengedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"RespondedExitChallenge\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"slot\",\"type\":\"uint64\"},{\"indexed\":false,\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"FinalizedExit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"FreedBond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"SlashedBond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"WithdrewBonds\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"mode\",\"type\":\"uint8\"},{\"indexed\":false,\"name\":\"contractAddress\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"uid\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"denomination\",\"type\":\"uint256\"}],\"name\":\"Withdrew\",\"type\":\"event\"},{\"constant\":false,\"inputs\":[{\"name\":\"root\",\"type\":\"bytes32\"}],\"name\":\"submitBlock\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"prevTxBytes\",\"type\":\"bytes\"},{\"name\":\"exitingTxBytes\",\"type\":\"bytes\"},{\"name\":\"prevTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"exitingTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"},{\"name\":\"blocks\",\"type\":\"uint256[2]\"}],\"name\":\"startExit\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"finalizeExit\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"finalizeExits\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"withdraw\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"prevTxBytes\",\"type\":\"bytes\"},{\"name\":\"txBytes\",\"type\":\"bytes\"},{\"name\":\"prevTxInclusionProof\",\"type\":\"bytes\"},{\"name\":\"txInclusionProof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"},{\"name\":\"blocks\",\"type\":\"uint256[2]\"}],\"name\":\"challengeBefore\",\"outputs\":[],\"payable\":true,\"stateMutability\":\"payable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingTxHash\",\"type\":\"bytes32\"},{\"name\":\"respondingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"respondingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"respondChallengeBefore\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"challengingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"challengeBetween\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"challengingBlockNumber\",\"type\":\"uint256\"},{\"name\":\"challengingTransaction\",\"type\":\"bytes\"},{\"name\":\"proof\",\"type\":\"bytes\"},{\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"challengeAfter\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"withdrawBonds\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_from\",\"type\":\"address\"},{\"name\":\"_amount\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC20Received\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes4\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_from\",\"type\":\"address\"},{\"name\":\"_uid\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC721Received\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes4\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"txHash\",\"type\":\"bytes32\"},{\"name\":\"root\",\"type\":\"bytes32\"},{\"name\":\"slot\",\"type\":\"uint64\"},{\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"checkMembership\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"getPlasmaCoin\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"uint8\"},{\"name\":\"\",\"type\":\"uint8\"},{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"slot\",\"type\":\"uint64\"}],\"name\":\"getExit\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\"},{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getBlockRoot\",\"outputs\":[{\"name\":\"root\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]"
 
 // RootChain is an auto generated Go binding around an Ethereum contract.
 type RootChain struct {
@@ -398,15 +398,16 @@ func (_RootChain *RootChainCallerSession) GetExit(slot uint64) (common.Address, 
 
 // GetPlasmaCoin is a free data retrieval call binding the contract method 0xf8353cf0.
 //
-// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint64, uint256, uint32, address, address, uint8)
-func (_RootChain *RootChainCaller) GetPlasmaCoin(opts *bind.CallOpts, slot uint64) (uint64, *big.Int, uint32, common.Address, common.Address, uint8, error) {
+// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint256, uint256, uint256, address, uint8, uint8, address)
+func (_RootChain *RootChainCaller) GetPlasmaCoin(opts *bind.CallOpts, slot uint64) (*big.Int, *big.Int, *big.Int, common.Address, uint8, uint8, common.Address, error) {
 	var (
-		ret0 = new(uint64)
+		ret0 = new(*big.Int)
 		ret1 = new(*big.Int)
-		ret2 = new(uint32)
+		ret2 = new(*big.Int)
 		ret3 = new(common.Address)
-		ret4 = new(common.Address)
+		ret4 = new(uint8)
 		ret5 = new(uint8)
+		ret6 = new(common.Address)
 	)
 	out := &[]interface{}{
 		ret0,
@@ -415,22 +416,23 @@ func (_RootChain *RootChainCaller) GetPlasmaCoin(opts *bind.CallOpts, slot uint6
 		ret3,
 		ret4,
 		ret5,
+		ret6,
 	}
 	err := _RootChain.contract.Call(opts, out, "getPlasmaCoin", slot)
-	return *ret0, *ret1, *ret2, *ret3, *ret4, *ret5, err
+	return *ret0, *ret1, *ret2, *ret3, *ret4, *ret5, *ret6, err
 }
 
 // GetPlasmaCoin is a free data retrieval call binding the contract method 0xf8353cf0.
 //
-// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint64, uint256, uint32, address, address, uint8)
-func (_RootChain *RootChainSession) GetPlasmaCoin(slot uint64) (uint64, *big.Int, uint32, common.Address, common.Address, uint8, error) {
+// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint256, uint256, uint256, address, uint8, uint8, address)
+func (_RootChain *RootChainSession) GetPlasmaCoin(slot uint64) (*big.Int, *big.Int, *big.Int, common.Address, uint8, uint8, common.Address, error) {
 	return _RootChain.Contract.GetPlasmaCoin(&_RootChain.CallOpts, slot)
 }
 
 // GetPlasmaCoin is a free data retrieval call binding the contract method 0xf8353cf0.
 //
-// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint64, uint256, uint32, address, address, uint8)
-func (_RootChain *RootChainCallerSession) GetPlasmaCoin(slot uint64) (uint64, *big.Int, uint32, common.Address, common.Address, uint8, error) {
+// Solidity: function getPlasmaCoin(slot uint64) constant returns(uint256, uint256, uint256, address, uint8, uint8, address)
+func (_RootChain *RootChainCallerSession) GetPlasmaCoin(slot uint64) (*big.Int, *big.Int, *big.Int, common.Address, uint8, uint8, common.Address, error) {
 	return _RootChain.Contract.GetPlasmaCoin(&_RootChain.CallOpts, slot)
 }
 
@@ -563,6 +565,27 @@ func (_RootChain *RootChainSession) FinalizeExits() (*types.Transaction, error) 
 // Solidity: function finalizeExits() returns()
 func (_RootChain *RootChainTransactorSession) FinalizeExits() (*types.Transaction, error) {
 	return _RootChain.Contract.FinalizeExits(&_RootChain.TransactOpts)
+}
+
+// OnERC20Received is a paid mutator transaction binding the contract method 0x65d83056.
+//
+// Solidity: function onERC20Received(_from address, _amount uint256,  bytes) returns(bytes4)
+func (_RootChain *RootChainTransactor) OnERC20Received(opts *bind.TransactOpts, _from common.Address, _amount *big.Int, arg2 []byte) (*types.Transaction, error) {
+	return _RootChain.contract.Transact(opts, "onERC20Received", _from, _amount, arg2)
+}
+
+// OnERC20Received is a paid mutator transaction binding the contract method 0x65d83056.
+//
+// Solidity: function onERC20Received(_from address, _amount uint256,  bytes) returns(bytes4)
+func (_RootChain *RootChainSession) OnERC20Received(_from common.Address, _amount *big.Int, arg2 []byte) (*types.Transaction, error) {
+	return _RootChain.Contract.OnERC20Received(&_RootChain.TransactOpts, _from, _amount, arg2)
+}
+
+// OnERC20Received is a paid mutator transaction binding the contract method 0x65d83056.
+//
+// Solidity: function onERC20Received(_from address, _amount uint256,  bytes) returns(bytes4)
+func (_RootChain *RootChainTransactorSession) OnERC20Received(_from common.Address, _amount *big.Int, arg2 []byte) (*types.Transaction, error) {
+	return _RootChain.Contract.OnERC20Received(&_RootChain.TransactOpts, _from, _amount, arg2)
 }
 
 // OnERC721Received is a paid mutator transaction binding the contract method 0xf0b9e5ba.
@@ -895,15 +918,15 @@ func (it *RootChainDepositIterator) Close() error {
 type RootChainDeposit struct {
 	Slot            uint64
 	BlockNumber     *big.Int
-	Denomination    uint64
+	Denomination    *big.Int
 	From            common.Address
 	ContractAddress common.Address
 	Raw             types.Log // Blockchain specific contextual infos
 }
 
-// FilterDeposit is a free log retrieval operation binding the contract event 0xd986268aed6074e7376db923df55ed41523cdf24bc906df2ad602751b0009834.
+// FilterDeposit is a free log retrieval operation binding the contract event 0xaa231413cf2b61ec7d73eeef7c722cd8ef6ed7a76e4d9e533867281e94f9a823.
 //
-// Solidity: e Deposit(slot indexed uint64, blockNumber uint256, denomination uint64, from indexed address, contractAddress indexed address)
+// Solidity: e Deposit(slot indexed uint64, blockNumber uint256, denomination uint256, from indexed address, contractAddress indexed address)
 func (_RootChain *RootChainFilterer) FilterDeposit(opts *bind.FilterOpts, slot []uint64, from []common.Address, contractAddress []common.Address) (*RootChainDepositIterator, error) {
 
 	var slotRule []interface{}
@@ -927,9 +950,9 @@ func (_RootChain *RootChainFilterer) FilterDeposit(opts *bind.FilterOpts, slot [
 	return &RootChainDepositIterator{contract: _RootChain.contract, event: "Deposit", logs: logs, sub: sub}, nil
 }
 
-// WatchDeposit is a free log subscription operation binding the contract event 0xd986268aed6074e7376db923df55ed41523cdf24bc906df2ad602751b0009834.
+// WatchDeposit is a free log subscription operation binding the contract event 0xaa231413cf2b61ec7d73eeef7c722cd8ef6ed7a76e4d9e533867281e94f9a823.
 //
-// Solidity: e Deposit(slot indexed uint64, blockNumber uint256, denomination uint64, from indexed address, contractAddress indexed address)
+// Solidity: e Deposit(slot indexed uint64, blockNumber uint256, denomination uint256, from indexed address, contractAddress indexed address)
 func (_RootChain *RootChainFilterer) WatchDeposit(opts *bind.WatchOpts, sink chan<- *RootChainDeposit, slot []uint64, from []common.Address, contractAddress []common.Address) (event.Subscription, error) {
 
 	var slotRule []interface{}
@@ -1763,6 +1786,142 @@ func (_RootChain *RootChainFilterer) WatchSubmittedBlock(opts *bind.WatchOpts, s
 				// New log arrived, parse the event and forward to the user
 				event := new(RootChainSubmittedBlock)
 				if err := _RootChain.contract.UnpackLog(event, "SubmittedBlock", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RootChainWithdrewIterator is returned from FilterWithdrew and is used to iterate over the raw logs and unpacked data for Withdrew events raised by the RootChain contract.
+type RootChainWithdrewIterator struct {
+	Event *RootChainWithdrew // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RootChainWithdrewIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RootChainWithdrew)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RootChainWithdrew)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RootChainWithdrewIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RootChainWithdrewIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RootChainWithdrew represents a Withdrew event raised by the RootChain contract.
+type RootChainWithdrew struct {
+	From            common.Address
+	Mode            uint8
+	ContractAddress common.Address
+	Uid             *big.Int
+	Denomination    *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterWithdrew is a free log retrieval operation binding the contract event 0xdf9b1156d45cedd38f6d4f4d1b7358b242045d6a14b7d94b87eaa231317870e8.
+//
+// Solidity: e Withdrew(from indexed address, mode uint8, contractAddress address, uid uint256, denomination uint256)
+func (_RootChain *RootChainFilterer) FilterWithdrew(opts *bind.FilterOpts, from []common.Address) (*RootChainWithdrewIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+
+	logs, sub, err := _RootChain.contract.FilterLogs(opts, "Withdrew", fromRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RootChainWithdrewIterator{contract: _RootChain.contract, event: "Withdrew", logs: logs, sub: sub}, nil
+}
+
+// WatchWithdrew is a free log subscription operation binding the contract event 0xdf9b1156d45cedd38f6d4f4d1b7358b242045d6a14b7d94b87eaa231317870e8.
+//
+// Solidity: e Withdrew(from indexed address, mode uint8, contractAddress address, uid uint256, denomination uint256)
+func (_RootChain *RootChainFilterer) WatchWithdrew(opts *bind.WatchOpts, sink chan<- *RootChainWithdrew, from []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+
+	logs, sub, err := _RootChain.contract.WatchLogs(opts, "Withdrew", fromRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RootChainWithdrew)
+				if err := _RootChain.contract.UnpackLog(event, "Withdrew", log); err != nil {
 					return err
 				}
 				event.Raw = log

--- a/client/plasma_cash/interface.go
+++ b/client/plasma_cash/interface.go
@@ -31,15 +31,15 @@ type Deposit interface {
 
 type ChainServiceClient interface {
 	CurrentBlock() (Block, error)
-	BlockNumber() (int64, error)
+	BlockNumber() (*big.Int, error)
 
-	Block(blknum int64) (Block, error)
+	Block(blknum *big.Int) (Block, error)
 	//Proof(blknum int64, slot uint64) (Proof, error)
 
 	SubmitBlock() error
 	Deposit(deposit *pctypes.DepositRequest) error
 
-	SendTransaction(slot uint64, prevBlock int64, denomination int64, newOwner, prevOwner string, sig []byte) error
+	SendTransaction(slot uint64, prevBlock *big.Int, denomination *big.Int, newOwner, prevOwner string, sig []byte) error
 }
 
 type Account struct {
@@ -49,8 +49,8 @@ type Account struct {
 
 type TokenContract interface {
 	Register() error
-	Deposit(int64) (common.Hash, error)
-	BalanceOf() (int64, error)
+	Deposit(*big.Int) (common.Hash, error)
+	BalanceOf() (*big.Int, error)
 
 	Account() (*Account, error)
 }
@@ -72,9 +72,9 @@ const (
 )
 
 type PlasmaCoin struct {
-	UID             uint64
-	DepositBlockNum int64
-	Denomination    uint64
+	UID             *big.Int
+	DepositBlockNum *big.Int
+	Denomination    *big.Int
 	Owner           string
 	ContractAddress string
 	State           PlasmaCoinState
@@ -101,19 +101,19 @@ type RootChainClient interface {
 	WithdrawBonds() error
 	PlasmaCoin(slot uint64) (*PlasmaCoin, error)
 	StartExit(slot uint64, prevTx Tx, exitingTx Tx, prevTxProof Proof,
-		exitingTxProof Proof, sigs []byte, prevTxBlkNum int64, txBlkNum int64) ([]byte, error)
+		exitingTxProof Proof, sigs []byte, prevTxBlkNum *big.Int, txBlkNum *big.Int) ([]byte, error)
 
 	ChallengeBefore(slot uint64, prevTx Tx, exitingTx Tx,
 		prevTxInclusionProof Proof, exitingTxInclusionProof Proof,
-		sig []byte, prevTxBlockNum int64, exitingTxBlockNum int64) ([]byte, error)
+		sig []byte, prevTxBlockNum *big.Int, exitingTxBlockNum *big.Int) ([]byte, error)
 
-	RespondChallengeBefore(slot uint64, challengingTxHash [32]byte, respondingBlockNumber int64,
+	RespondChallengeBefore(slot uint64, challengingTxHash [32]byte, respondingBlockNumber *big.Int,
 		respondingTransaction Tx, proof Proof, sig []byte) ([]byte, error)
 
-	ChallengeBetween(slot uint64, challengingBlockNumber int64,
+	ChallengeBetween(slot uint64, challengingBlockNumber *big.Int,
 		challengingTransaction Tx, proof Proof, sig []byte) ([]byte, error)
 
-	ChallengeAfter(slot uint64, challengingBlockNumber int64,
+	ChallengeAfter(slot uint64, challengingBlockNumber *big.Int,
 		challengingTransaction Tx, proof Proof, sig []byte) ([]byte, error)
 
 	SubmitBlock(blockNum *big.Int, merkleRoot [32]byte) error

--- a/client/plasma_cash/interface.go
+++ b/client/plasma_cash/interface.go
@@ -60,17 +60,25 @@ type PlasmaCoinState uint8
 const (
 	PlasmaCoinDeposited PlasmaCoinState = iota
 	PlasmaCoinExiting
-	PlasmaCoinChallenged
 	PlasmaCoinExited
+)
+
+type PlasmaCoinMode uint8
+
+const (
+	PlasmaCoinEth PlasmaCoinMode = iota
+	PlasmaCoinERC20
+	PlasmaCoinERC721
 )
 
 type PlasmaCoin struct {
 	UID             uint64
 	DepositBlockNum int64
-	Denomination    uint32
+	Denomination    uint64
 	Owner           string
 	ContractAddress string
 	State           PlasmaCoinState
+	Mode            PlasmaCoinMode
 }
 
 type DepositEventData struct {
@@ -83,7 +91,7 @@ type DepositEventData struct {
 type ChallengedExitEventData struct {
 	// Plasma slot, a unique identifier, assigned to the deposit.
 	Slot uint64
-    // Hash of the transaction used for the response to a challenge.
+	// Hash of the transaction used for the response to a challenge.
 	TxHash [32]byte
 }
 

--- a/client/plasma_cash/interface.go
+++ b/client/plasma_cash/interface.go
@@ -39,7 +39,7 @@ type ChainServiceClient interface {
 	SubmitBlock() error
 	Deposit(deposit *pctypes.DepositRequest) error
 
-	SendTransaction(slot uint64, prevBlock *big.Int, denomination *big.Int, newOwner, prevOwner string, sig []byte) error
+	SendTransaction(slot uint64, prevBlock *big.Int, denomination *big.Int, newOwner string, prevOwner string, sig []byte) error
 }
 
 type Account struct {

--- a/client/plasma_cash/transaction.go
+++ b/client/plasma_cash/transaction.go
@@ -16,7 +16,7 @@ import (
 
 type LoomTx struct {
 	Slot         uint64
-	Denomination uint32 //TODO should be bigint
+	Denomination *big.Int
 	Owner        common.Address
 	PrevBlock    *big.Int
 	Signature    []byte
@@ -41,7 +41,7 @@ func (l *LoomTx) Sign(key *ecdsa.PrivateKey) ([]byte, error) {
 		return nil, err
 	}
 
-	// The first byte should be the signature more, for details about the signature format refer to
+	// The first byte should be the signature mode, for details about the signature format refer to
 	// https://github.com/loomnetwork/plasma-erc721/blob/master/server/contracts/Libraries/ECVerify.sol
 	return append(make([]byte, 1, 66), sig...), nil
 }
@@ -49,14 +49,14 @@ func (l *LoomTx) Sign(key *ecdsa.PrivateKey) ([]byte, error) {
 func (l *LoomTx) RlpEncode() ([]byte, error) {
 	return rlp.EncodeToBytes([]interface{}{
 		uint64(l.Slot),
-		l.PrevBlock.Uint64(),
+		l.PrevBlock,
 		l.Denomination,
 		l.Owner,
 	})
 }
 
 func (l *LoomTx) Hash() []byte {
-	if l.PrevBlock.Int64() != 0 {
+	if l.PrevBlock.Cmp(big.NewInt(0)) != 0 {
 		ret, err := l.rlpEncodeWithSha3()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
- Remove redundant coin state `CHALLENGED`
- Add coin mode (ETH/ERC20/ERC721)

Required for the `Deposit` and `getPlasmaCoin` interface changes in https://github.com/loomnetwork/plasma-erc721/pull/83