### PR TITLE
Minor cleanup of contractpb.Static/Context

### DIFF
--- a/plugin/contract.go
+++ b/plugin/contract.go
@@ -56,6 +56,9 @@ type RangeEntry struct {
 // RangeData an array of key value pairs for a range of data
 type RangeData []*RangeEntry
 
+// StaticContext is the low-level context provided to RequestDispatcher.Call().
+// The primary implementation of this interface is plugin.contractContext (loomchain/plugin package).
+// For external GRPC contracts plugin.contractContext is wrapped by GRPCContext (go-loom/plugin package).
 type StaticContext interface {
 	StaticAPI
 	Get(key []byte) []byte
@@ -67,6 +70,7 @@ type StaticContext interface {
 	ContractAddress() loom.Address
 }
 
+// Context is the low-level context provided to RequestDispatcher.StaticCall().
 type Context interface {
 	StaticContext
 	VolatileAPI

--- a/plugin/contractpb/contractpb.go
+++ b/plugin/contractpb/contractpb.go
@@ -18,6 +18,7 @@ var (
 	ErrNotFound = errors.New("not found")
 )
 
+// StaticContext is the high-level context provided to Go contract methods that don't mutate state.
 type StaticContext interface {
 	plugin.StaticAPI
 	Get(key []byte, pb proto.Message) error
@@ -28,15 +29,16 @@ type StaticContext interface {
 	Message() plugin.Message
 	ContractAddress() loom.Address
 	Logger() *loom.Logger
+	HasPermissionFor(addr loom.Address, token []byte, roles []string) (bool, []string)
 }
 
+// Context is the high-level context provided to Go contract methods that mutate state.
 type Context interface {
 	plugin.VolatileAPI
 	StaticContext
 	Set(key []byte, pb proto.Message) error
 	Delete(key []byte)
 	HasPermission(token []byte, roles []string) (bool, []string)
-	HasPermissionFor(addr loom.Address, token []byte, roles []string) (bool, []string)
 	GrantPermissionTo(addr loom.Address, token []byte, role string)
 	RevokePermissionFrom(addr loom.Address, token []byte, role string)
 	GrantPermission(token []byte, roles []string)
@@ -46,6 +48,7 @@ type Contract interface {
 	Meta() (plugin.Meta, error)
 }
 
+// Implements the StaticContext interface for Go contract methods.
 type wrappedPluginStaticContext struct {
 	plugin.StaticContext
 	logger *loom.Logger
@@ -66,29 +69,30 @@ func (c *wrappedPluginStaticContext) Get(key []byte, pb proto.Message) error {
 	return proto.Unmarshal(data, pb)
 }
 
-func (c *wrappedPluginStaticContext) Range(prefix []byte) plugin.RangeData {
-	//TODO should we auto unprotobuf each entry like Get method does?
-	return c.StaticContext.Range(prefix)
+// HasPermissionFor checks whether the given `addr` has any of the permission given in `roles` on `token`
+func (c *wrappedPluginStaticContext) HasPermissionFor(addr loom.Address, token []byte, roles []string) (bool, []string) {
+	found := false
+	foundRoles := []string{}
+	for _, role := range roles {
+		v := c.StaticContext.Get(rolePermKey(addr, token, role))
+		if v != nil && string(v) == "true" {
+			found = true
+			foundRoles = append(foundRoles, role)
+		}
+	}
+	return found, foundRoles
 }
 
+// Implements the Context interface for Go contract methods.
 type wrappedPluginContext struct {
 	plugin.Context
-	logger *loom.Logger
+	wrappedPluginStaticContext
 }
 
 var _ Context = &wrappedPluginContext{}
 
-func (c *wrappedPluginContext) Logger() *loom.Logger {
-	return c.logger
-}
-
 func (c *wrappedPluginContext) Get(key []byte, pb proto.Message) error {
-	data := c.Context.Get(key)
-	if len(data) == 0 {
-		return ErrNotFound
-	}
-
-	return proto.Unmarshal(data, pb)
+	return c.wrappedPluginStaticContext.Get(key, pb)
 }
 
 func (c *wrappedPluginContext) Set(key []byte, pb proto.Message) error {
@@ -104,20 +108,6 @@ func (c *wrappedPluginContext) Set(key []byte, pb proto.Message) error {
 func (c *wrappedPluginContext) HasPermission(token []byte, roles []string) (bool, []string) {
 	addr := c.Message().Sender
 	return c.HasPermissionFor(addr, token, roles)
-}
-
-// HasPermissionFor checks whether the given `addr` has any of the permission given in `roles` on `token`
-func (c *wrappedPluginContext) HasPermissionFor(addr loom.Address, token []byte, roles []string) (bool, []string) {
-	found := false
-	foundRoles := []string{}
-	for _, role := range roles {
-		v := c.Context.Get(rolePermKey(addr, token, role))
-		if v != nil && string(v) == "true" {
-			found = true
-			foundRoles = append(foundRoles, role)
-		}
-	}
-	return found, foundRoles
 }
 
 // GrantPermissionTo sets a given `role` permission on `token` for the given `addr`
@@ -265,7 +255,7 @@ func StaticCallEVM(ctx StaticContext, addr loom.Address, input []byte, output *[
 }
 
 func WrapPluginContext(ctx plugin.Context) Context {
-	return &wrappedPluginContext{ctx, logger}
+	return &wrappedPluginContext{ctx, wrappedPluginStaticContext{ctx, logger}}
 }
 
 func WrapPluginStaticContext(ctx plugin.StaticContext) StaticContext {


### PR DESCRIPTION
- Move `HasPermissionFor()` from `wrappedPluginContext` to `wrappedPluginStaticContext` because it doesn't modify state.
- Remove `Range()` from `wrappedPluginStaticContext` since the function signature and implementation is identical to the one provided by the embedded `plugin.StaticContext`.
- Embed `wrappedPluginStaticContext` in `wrappedPluginContext` to avoid reimplementing shared interface methods.