### PR TITLE
[WIP] Fix keys returned by FakeContext.Range()

### DIFF
--- a/plugin/mock_context.go
+++ b/plugin/mock_context.go
@@ -196,8 +196,14 @@ func (c *FakeContext) EmitTopics(event []byte, topics ...string) {
 func (c *FakeContext) Emit(event []byte) {
 }
 
+// Prefix the given key with the contract address
 func (c *FakeContext) makeKey(key []byte) string {
 	return string(util.PrefixKey(c.address.Bytes(), key))
+}
+
+// Strip the contract address from the given key (i.e. inverse of makeKey)
+func (c *FakeContext) recoverKey(key string) []byte {
+	return []byte(key)[len(c.address.Bytes())+1:]
 }
 
 func (c *FakeContext) Range(prefix []byte) RangeData {
@@ -207,7 +213,7 @@ func (c *FakeContext) Range(prefix []byte) RangeData {
 	for key, value := range c.data {
 		if strings.HasPrefix(key, keyedPrefix) == true {
 			r := &RangeEntry{
-				Key:   []byte(key),
+				Key:   c.recoverKey(key),
 				Value: value,
 			}
 

--- a/plugin/mock_context_test.go
+++ b/plugin/mock_context_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"bytes"
 	"testing"
 
 	loom "github.com/loomnetwork/go-loom"
@@ -25,4 +26,12 @@ func TestRange(t *testing.T) {
 
 	//The mock context uses map underneath and the real context does not so ordering will be different then real server!
 	//	assert.Equal(t, string(s.makeKey([]byte("bob5"))), string(data[0].Key))
+}
+
+func TestPrefixedKeys(t *testing.T) {
+	addr1 := loom.MustParseAddress("chain:0xb16a379ec18d4093666f8f38b11a3071c920207d")
+
+	c := CreateFakeContext(addr1, addr1)
+	unprefixedKey := []byte("placeholder")
+	assert.Equal(t, 0, bytes.Compare(c.recoverKey(c.makeKey(unprefixedKey)), unprefixedKey))
 }


### PR DESCRIPTION
The context prefixes keys by the contract address, this prefix should be stripped when setting the key of each `RangeEntry` so that it can be used with the `FakeContext.Get/Set/Has` functions which prefix each key (thus resulting in a duplicated prefix when passing in `RangeEntry.Key`).