### PR TITLE
Fix register_candidate commands to only accept base64 encoded pub keys

### DIFF
--- a/builtin/commands/dposV2_commands.go
+++ b/builtin/commands/dposV2_commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -58,7 +59,7 @@ func RegisterCandidateCmdV2() *cobra.Command {
 		Short: "Register a candidate for validator",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pubKey, err := cli.ParseBytes(args[0])
+			pubKey, err := base64.StdEncoding.DecodeString(args[0])
 			if err != nil {
 				return err
 			}
@@ -86,7 +87,7 @@ func DelegateCmdV2() *cobra.Command {
 
 			return cli.CallContract(DPOSV2ContractName, "Delegate", &dposv2.DelegateRequestV2{
 				ValidatorAddress: addr.MarshalPB(),
-				Amount:           &types.BigUInt{
+				Amount: &types.BigUInt{
 					Value: *amount,
 				},
 			}, nil)
@@ -140,7 +141,7 @@ func UnbondCmdV2() *cobra.Command {
 			}
 			return cli.CallContract(DPOSV2ContractName, "Unbond", &dposv2.UnbondRequestV2{
 				ValidatorAddress: addr.MarshalPB(),
-				Amount:           &types.BigUInt{
+				Amount: &types.BigUInt{
 					Value: *amount,
 				},
 			}, nil)

--- a/builtin/commands/dpos_commands.go
+++ b/builtin/commands/dpos_commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 
@@ -58,7 +59,7 @@ func RegisterCandidateCmd() *cobra.Command {
 		Short: "Register a candidate for witness",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pubKey, err := cli.ParseBytes(args[0])
+			pubKey, err := base64.StdEncoding.DecodeString(args[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
As it turns out, base64 encoded strings can start with 0x too.