### PR TITLE
Add gateway validator commands

### DIFF
--- a/builtin/commands/commands.go
+++ b/builtin/commands/commands.go
@@ -19,4 +19,5 @@ func Add(cmd *cobra.Command) {
 	AddDPOSV2(cmd)
 	AddCoin(cmd)
 	AddGeneralCommands(cmd)
+    AddValidatorCommands(cmd)
 }

--- a/builtin/commands/validator_commands.go
+++ b/builtin/commands/validator_commands.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/loomnetwork/go-loom/client/gateway"
+	"github.com/loomnetwork/go-loom/cli"
+
+	ssha "github.com/miguelmota/go-solidity-sha3"
+
+    "github.com/ethereum/go-ethereum/crypto"
+    ethclient "github.com/ethereum/go-ethereum/ethclient"
+	"github.com/spf13/cobra"
+)
+
+func SignRemoveValidator() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove [validator eth address] [gateway mainnet address] [signer eth key path] [eth endpoint]",
+		Short: "Returns a signature for the addition of a new validator. Must be sorted together with the other signatures to match the multisig threshold",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			validator := args[0]
+			privateKeyPath := args[1]
+			gatewayAddr := cli.TxFlags.ContractAddr
+			ethUri := cli.TxFlags.MainnetURI
+
+            // Get the nonce
+            ethClient, err := ethclient.Dial(ethUri)
+			gatewayClient, err := gateway.ConnectToMainnetGateway(ethClient, gatewayAddr)
+			nonce, err := gatewayClient.Contract().Nonce(nil)
+			if err != nil {
+				return err
+			}
+
+			operation := "remove"
+			hash := ssha.SoliditySHA3(
+				ssha.Address(gatewayAddr),
+				ssha.Uint256(nonce),
+				ssha.SoliditySHA3(
+					ssha.String(operation),
+					ssha.Address(validator),
+				),
+			)
+
+            // TODO: Check if hsmconfigfile flag is given-> use that, otherwise privfile
+			key, err := crypto.LoadECDSA(privateKeyPath)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			sig, err := crypto.Sign(hash, key)
+			if err != nil {
+				fmt.Println(err)
+
+			}
+			fmt.Printf("Operation: %s %s\n", operation, validator)
+			fmt.Printf("Gateway Address: %s\n", gatewayAddr)
+			fmt.Printf("Gateway Nonce: %d\n", nonce)
+			fmt.Printf("Signer: %s\n", crypto.PubkeyToAddress(key.PublicKey).String())
+			fmt.Printf("Msg hash: %s\n", hex.EncodeToString(hash))
+			fmt.Printf("{signer: %s, signature: 0x%s}\n", crypto.PubkeyToAddress(key.PublicKey).String(), hex.EncodeToString(sig))
+			return nil
+		},
+	}
+}
+
+func SignAddValidator() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add [validator eth address] [gateway mainnet address] [signer eth key path] [eth endpoint",
+		Short: "Returns a signature for the addition of a new validator. Must be sorted together with the other signatures to match the multisig threshold",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			validator := args[0]
+			privateKeyPath := args[1]
+			gatewayAddr := cli.TxFlags.ContractAddr
+			ethUri := cli.TxFlags.MainnetURI
+
+            // Get the nonce
+            ethClient, err := ethclient.Dial(ethUri)
+			gatewayClient, err := gateway.ConnectToMainnetGateway(ethClient, gatewayAddr)
+			nonce, err := gatewayClient.Contract().Nonce(nil)
+			if err != nil {
+				return err
+			}
+
+			operation := "add"
+			hash := ssha.SoliditySHA3(
+				ssha.Address(gatewayAddr),
+				ssha.Uint256(nonce),
+				ssha.SoliditySHA3(
+					ssha.String(operation),
+					ssha.Address(validator),
+				),
+			)
+			key, err := crypto.LoadECDSA(privateKeyPath)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			sig, err := crypto.Sign(hash, key)
+			if err != nil {
+				fmt.Println(err)
+
+			}
+			fmt.Printf("Operation: %s %s\n", operation, validator)
+			fmt.Printf("Gateway Address: %s\n", gatewayAddr)
+			fmt.Printf("Gateway Nonce: %d\n", nonce)
+			fmt.Printf("Signer: %s\n", crypto.PubkeyToAddress(key.PublicKey).String())
+			fmt.Printf("Msg hash: 0x%s\n", hex.EncodeToString(hash))
+			fmt.Printf("{signer: %s, signature: 0x%s}\n", crypto.PubkeyToAddress(key.PublicKey).String(), hex.EncodeToString(sig))
+			return nil
+		},
+	}
+}
+
+func AddValidatorCommands(root *cobra.Command) {
+	root.AddCommand(
+		SignAddValidator(),
+		SignRemoveValidator(),
+	)
+}

--- a/builtin/commands/validator_commands.go
+++ b/builtin/commands/validator_commands.go
@@ -1,3 +1,5 @@
+// +build evm
+
 package commands
 
 import (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 var TxFlags struct {
 	WriteURI      string
 	ReadURI       string
+	MainnetURI    string
 	ContractAddr  string
 	ChainID       string
 	PrivFile      string
@@ -35,6 +36,7 @@ func ContractCallCommand(name string) *cobra.Command {
 	pflags := cmd.PersistentFlags()
 	pflags.StringVarP(&TxFlags.WriteURI, "write", "w", "http://localhost:46658/rpc", "URI for sending txs")
 	pflags.StringVarP(&TxFlags.ReadURI, "read", "r", "http://localhost:46658/query", "URI for quering app state")
+	pflags.StringVarP(&TxFlags.MainnetURI, "ethereum", "e", "http://localhost:8545", "URI for talking to Ethereum")
 	pflags.StringVarP(&TxFlags.ContractAddr, "contract", "", "", "contract address")
 	pflags.StringVarP(&TxFlags.ChainID, "chain", "", "default", "chain ID")
 	pflags.StringVarP(&TxFlags.PrivFile, "key", "k", "", "private key file")
@@ -51,6 +53,7 @@ func ContractResolveCommand() *cobra.Command {
 	pflags := cmd.PersistentFlags()
 	pflags.StringVarP(&TxFlags.WriteURI, "write", "w", "http://localhost:46658/rpc", "URI for sending txs")
 	pflags.StringVarP(&TxFlags.ReadURI, "read", "r", "http://localhost:46658/query", "URI for quering app state")
+	pflags.StringVarP(&TxFlags.MainnetURI, "ethereum", "e", "http://localhost:8545", "URI for talking to Ethereum")
 	pflags.StringVarP(&TxFlags.ContractAddr, "contract", "", "", "contract name")
 	pflags.StringVarP(&TxFlags.ChainID, "chain", "", "default", "chain ID")
 	pflags.StringVarP(&TxFlags.PrivFile, "key", "k", "", "private key file")

--- a/client/gateway/mainnet_gateway_client.go
+++ b/client/gateway/mainnet_gateway_client.go
@@ -23,6 +23,10 @@ type MainnetGatewayClient struct {
 	TxTimeout time.Duration
 }
 
+func (c *MainnetGatewayClient) Contract() *MainnetGatewayContract {
+    return c.contract
+}
+
 func (c *MainnetGatewayClient) DepositERC20(caller *client.Identity, amount *big.Int, tokenAddr common.Address) error {
 	tx, err := c.contract.DepositERC20(client.DefaultTransactOptsForIdentity(caller), amount, tokenAddr)
 	if err != nil {


### PR DESCRIPTION
Add bindings to generate signatures for adding/removing validators to the mainnet gateways.

Does not support Yubi signing yet. 