### PR TITLE
Fix vendor packages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,19 +14,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/gogo/protobuf"
-  packages = [
-    "gogoproto",
-    "jsonpb",
-    "proto",
-    "protoc-gen-gogo/descriptor",
-    "sortkeys",
-    "types"
-  ]
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -49,12 +36,6 @@
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/go-plugin"
-  packages = ["."]
-  revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
 
 [[projects]]
   branch = "master"
@@ -129,18 +110,6 @@
   revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
-  name = "github.com/spf13/cobra"
-  packages = ["."]
-  revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
-  version = "v0.0.2"
-
-[[projects]]
-  name = "github.com/spf13/pflag"
-  packages = ["."]
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -200,39 +169,6 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   revision = "86e600f69ee4704c6efbf6a2a40a5c10700e76c2"
-
-[[projects]]
-  name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "channelz",
-    "codes",
-    "connectivity",
-    "credentials",
-    "encoding",
-    "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "health",
-    "health/grpc_health_v1",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
-  revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
-  version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ deps:
 		github.com/go-kit/kit/log \
 		github.com/pkg/errors
 	dep ensure -vendor-only
+	cd $(GOGO_PROTOBUF_DIR) && git checkout v1.1.1
 	cd $(HASHICORP_DIR) && git checkout f4c3476bd38585f9ec669d10ed1686abd52b9961
 
 deps-evm:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ deps:
 		github.com/go-kit/kit/log \
 		github.com/pkg/errors
 	dep ensure -vendor-only
-	cd $(GOGO_PROTOBUF_DIR) && git checkout 1ef32a8b9fc3f8ec940126907cedb5998f6318e4
 	cd $(HASHICORP_DIR) && git checkout f4c3476bd38585f9ec669d10ed1686abd52b9961
 
 deps-evm:


### PR DESCRIPTION
This PR will fix issue mismatched gogo protobuf issue when compiling loomchain.

Changes:
- remove vendor packages that have been fetched by `go get`
- pin gogo protobuf to v1.1.1