### PR TITLE
fix FeatureEnabled loop wrappedPluginContext

### DIFF
--- a/plugin/contractpb/contractpb.go
+++ b/plugin/contractpb/contractpb.go
@@ -133,7 +133,7 @@ func (c *wrappedPluginContext) RevokePermissionFrom(addr loom.Address, token []b
 
 // Check if feature is enabled on chain
 func (c *wrappedPluginContext) FeatureEnabled(name string, defaultVal bool) bool {
-	return c.FeatureEnabled(name, defaultVal)
+	return c.Context.FeatureEnabled(name, defaultVal)
 }
 
 func rolePermKey(addr loom.Address, token []byte, role string) []byte {


### PR DESCRIPTION
Calling FeatureEnabled of fakeContext will get stack overflow because it does not whether to call FeatureEnabled in `plugin.Context` or `wrappedPluginStaticContext`.