### PR TITLE
add constants for prefixes & extract withdrawalHash function

### DIFF
--- a/client/gateway_v2/mainnet_gateway_client.go
+++ b/client/gateway_v2/mainnet_gateway_client.go
@@ -127,7 +127,7 @@ func (c *MainnetGatewayClient) withdrawalHash(withdrawer common.Address, tokenAd
 	if err != nil {
 		return nil
 	}
-	hash := client.WithdrawalHash(withdrawer, tokenAddr, c.Address, tokenKind, tokenId, amount, nonce)
+	hash := client.WithdrawalHash(withdrawer, tokenAddr, c.Address, tokenKind, tokenId, amount, nonce, true)
 	return ssha.SoliditySHA3(
 		[]string{"string", "bytes32"},
 		"\x19Ethereum Signed Message:\n32",

--- a/client/gateway_v2/mainnet_gateway_client.go
+++ b/client/gateway_v2/mainnet_gateway_client.go
@@ -131,21 +131,31 @@ func (c *MainnetGatewayClient) withdrawalHash(withdrawer common.Address, tokenAd
 			[]string{"uint256", "address"},
 			tokenId, tokenAddr,
 		)
+		prefix = client.ERC721Prefix
 	case tgtypes.TransferGatewayTokenKind_ERC721X:
 		hash = ssha.SoliditySHA3(
 			[]string{"uint256", "uint256", "address"},
 			tokenId, amount, tokenAddr,
 		)
+		prefix = client.ERC721XPrefix
+	case tgtypes.TransferGatewayTokenKind_LOOMCOIN:
+		hash = ssha.SoliditySHA3(
+			[]string{"uint256", "address"},
+			amount, tokenAddr,
+		)
+		prefix = client.ERC20Prefix
 	case tgtypes.TransferGatewayTokenKind_ERC20:
 		hash = ssha.SoliditySHA3(
 			[]string{"uint256", "address"},
 			amount, tokenAddr,
 		)
+		prefix = client.ERC20Prefix
 	case tgtypes.TransferGatewayTokenKind_ETH:
 		hash = ssha.SoliditySHA3(
 			[]string{"uint256"},
 			amount,
 		)
+		prefix = client.ETHPrefix
 	default:
 		return nil
 	}
@@ -157,8 +167,8 @@ func (c *MainnetGatewayClient) withdrawalHash(withdrawer common.Address, tokenAd
 
 	// Make it non replayable
 	hash = ssha.SoliditySHA3(
-		[]string{"address", "uint256", "address", "bytes32"},
-		withdrawer, nonce, c.Address, hash,
+		[]string{"string", "address", "uint256", "address", "bytes32"},
+		prefix, withdrawer, nonce, c.Address, hash,
 	)
 
 	// Prefix the hash with the Ethereum Signed Message

--- a/client/gateway_v2/mainnet_gateway_client.go
+++ b/client/gateway_v2/mainnet_gateway_client.go
@@ -125,6 +125,7 @@ func (c *MainnetGatewayClient) WithdrawETH(caller *client.Identity, amount *big.
 func (c *MainnetGatewayClient) withdrawalHash(withdrawer common.Address, tokenAddr common.Address, tokenKind tgtypes.TransferGatewayTokenKind, tokenId *big.Int, amount *big.Int) []byte {
 	// Create hash of the message
 	var hash []byte
+	var prefix string
 	switch tokenKind {
 	case tgtypes.TransferGatewayTokenKind_ERC721:
 		hash = ssha.SoliditySHA3(

--- a/client/gateway_v2/mainnet_gateway_client.go
+++ b/client/gateway_v2/mainnet_gateway_client.go
@@ -4,6 +4,7 @@ package gateway_v2
 
 import (
 	"context"
+	ssha "github.com/miguelmota/go-solidity-sha3"
 	"math/big"
 	"time"
 
@@ -126,7 +127,12 @@ func (c *MainnetGatewayClient) withdrawalHash(withdrawer common.Address, tokenAd
 	if err != nil {
 		return nil
 	}
-	return client.WithdrawalHash(withdrawer, tokenAddr, c.Address, tokenKind, tokenId, amount, nonce)
+	hash := client.WithdrawalHash(withdrawer, tokenAddr, c.Address, tokenKind, tokenId, amount, nonce)
+	return ssha.SoliditySHA3(
+		[]string{"string", "bytes32"},
+		"\x19Ethereum Signed Message:\n32",
+		hash,
+	)
 }
 
 func ConnectToMainnetGateway(ethClient *ethclient.Client, gatewayAddr string) (*MainnetGatewayClient, error) {

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -20,6 +20,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	ERC721Prefix  = "\x16Withdraw ERC721:\n"
+	ERC721XPrefix = "\x15Withdraw ERC721X:\n"
+	ERC20Prefix   = "\x14Withdraw ERC20:\n"
+	ETHPrefix     = "\x13Withdraw ETH:\n"
+)
+
 var ErrTxFailed = errors.New("tx failed")
 var ErrValnotFound = errors.New("validator not found")
 

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -5,6 +5,7 @@ package client
 import (
 	"context"
 	"fmt"
+	ssha "github.com/miguelmota/go-solidity-sha3"
 	"math/big"
 	"os"
 	"sort"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	tgtypes "github.com/loomnetwork/go-loom/builtin/types/transfer_gateway"
 	"github.com/loomnetwork/go-loom/common/evmcompat"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -146,7 +148,7 @@ func ParseSigs(sigs []byte, hash []byte, validators []common.Address) ([]uint8, 
 		// Try to find the validator
 		index, err := indexOfValidator(validator, validators)
 		if err != nil {
-			fmt.Println("validator not found", validator)
+			fmt.Println("validator not found", validator.String())
 			continue
 		}
 
@@ -249,6 +251,55 @@ func split(buf []byte, lim int) [][]byte {
 		chunks = append(chunks, buf[:len(buf)])
 	}
 	return chunks
+}
+
+func WithdrawalHash(withdrawer common.Address, tokenAddr common.Address, gatewayAddr common.Address, tokenKind tgtypes.TransferGatewayTokenKind, tokenId *big.Int, amount *big.Int, nonce *big.Int) []byte {
+	// Create hash of the message
+	var hash []byte
+	var prefix string
+	switch tokenKind {
+	case tgtypes.TransferGatewayTokenKind_ERC721:
+		hash = ssha.SoliditySHA3(
+			[]string{"uint256", "address"},
+			tokenId, tokenAddr,
+		)
+		prefix = ERC721Prefix
+	case tgtypes.TransferGatewayTokenKind_ERC721X:
+		hash = ssha.SoliditySHA3(
+			[]string{"uint256", "uint256", "address"},
+			tokenId, amount, tokenAddr,
+		)
+		prefix = ERC721XPrefix
+	case tgtypes.TransferGatewayTokenKind_LOOMCOIN, tgtypes.TransferGatewayTokenKind_ERC20:
+		hash = ssha.SoliditySHA3(
+			[]string{"uint256", "address"},
+			amount, tokenAddr,
+		)
+		prefix = ERC20Prefix
+	case tgtypes.TransferGatewayTokenKind_ETH:
+		hash = ssha.SoliditySHA3(
+			[]string{"uint256"},
+			amount,
+		)
+		prefix = ETHPrefix
+	default:
+		return nil
+	}
+
+	// Make it non replayable
+	hash = ssha.SoliditySHA3(
+		[]string{"string", "address", "uint256", "address", "bytes32"},
+		prefix, withdrawer, nonce, gatewayAddr, hash,
+	)
+
+	// Prefix the hash with the Ethereum Signed Message
+	hash = ssha.SoliditySHA3(
+		[]string{"string", "bytes32"},
+		"\x19Ethereum Signed Message:\n32",
+		hash,
+	)
+
+	return hash
 }
 
 // Taken from: https://github.com/cznic/sortutil/blob/master/sortutil.go

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -253,7 +253,7 @@ func split(buf []byte, lim int) [][]byte {
 	return chunks
 }
 
-func WithdrawalHash(withdrawer common.Address, tokenAddr common.Address, gatewayAddr common.Address, tokenKind tgtypes.TransferGatewayTokenKind, tokenId *big.Int, amount *big.Int, nonce *big.Int) []byte {
+func WithdrawalHash(withdrawer common.Address, tokenAddr common.Address, gatewayAddr common.Address, tokenKind tgtypes.TransferGatewayTokenKind, tokenId *big.Int, amount *big.Int, nonce *big.Int, shouldPrefix bool) []byte {
 	// Create hash of the message
 	var hash []byte
 	var prefix string
@@ -287,10 +287,17 @@ func WithdrawalHash(withdrawer common.Address, tokenAddr common.Address, gateway
 	}
 
 	// Make it non replayable
-	hash = ssha.SoliditySHA3(
-		[]string{"string", "address", "uint256", "address", "bytes32"},
-		prefix, withdrawer, nonce, gatewayAddr, hash,
-	)
+	if shouldPrefix {
+		hash = ssha.SoliditySHA3(
+			[]string{"string", "address", "uint256", "address", "bytes32"},
+			prefix, withdrawer, nonce, gatewayAddr, hash,
+		)
+	} else {
+		hash = ssha.SoliditySHA3(
+			[]string{"address", "uint256", "address", "bytes32"},
+			withdrawer, nonce, gatewayAddr, hash,
+		)
+	}
 
 	return hash
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -292,13 +292,6 @@ func WithdrawalHash(withdrawer common.Address, tokenAddr common.Address, gateway
 		prefix, withdrawer, nonce, gatewayAddr, hash,
 	)
 
-	// Prefix the hash with the Ethereum Signed Message
-	hash = ssha.SoliditySHA3(
-		[]string{"string", "bytes32"},
-		"\x19Ethereum Signed Message:\n32",
-		hash,
-	)
-
 	return hash
 }
 


### PR DESCRIPTION
From the audit, the contracts were adjusted to have the described feature. As a result, the client must be modified accordingly.

---

If someone creates a new message type one day, and they forget to include an identifier, then one of these signatures might be reused for messages of that new type.

Instead, I would use string identifiers.  For example, you might change `createMessageWithdraw` to look like this:
  ```
function createMessageWithdraw(string memory prefix, bytes32 hash)
    internal
    view
    returns (bytes32)
  {
    return keccak256(
      abi.encodePacked(
        prefix,             // <== Newly added string identifier.
        msg.sender,
        nonces[msg.sender],
        address(this),
        hash
      )
    );
  }
```

And, say, use it in `withdrawERC20` like this:
```
bytes32 message = createMessageWithdraw(
            "\x15Loom Withdraw ERC20:\n",
            keccak256(abi.encodePacked(amount, contractAddress))
    );
```

And in `withdrawETH` like this:

```
bytes32 message = createMessageWithdraw(
            "\x13Loom Withdraw ETH:\n",
            keccak256(abi.encodePacked(amount))
    );
```

Note also that adding an argument to `createMessageWithdraw` forces one to remember to include an identifier.  But, as I said, I think you've closed the immediate loophole.  So, to a certain extent, these are stylistic choices.