### PR TITLE
fix a bug in util.UnprefixKey

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -26,7 +26,7 @@ func UnprefixKey(key, prefix []byte) ([]byte, error) {
 	if len(prefix)+1 > len(key) {
 		return nil, fmt.Errorf("prefix %s longer than key %s", string(prefix), string(key))
 	}
-	return key[len(prefix)+1:], nil
+	return key[len(prefix):], nil
 }
 
 func FileExists(filePath string) bool {


### PR DESCRIPTION
Currently `UnprefixKey` function in `util/util.go` returns incorrect unprefixed key as it removes `prefix + one character` from `key`.