### PR TITLE
Use message lengths that are consistent with eth_sign

### DIFF
--- a/client/helpers.go
+++ b/client/helpers.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	ERC721Prefix  = "\x16Withdraw ERC721:\n"
-	ERC721XPrefix = "\x15Withdraw ERC721X:\n"
-	ERC20Prefix   = "\x14Withdraw ERC20:\n"
-	ETHPrefix     = "\x13Withdraw ETH:\n"
+	ETHPrefix     = "\x0eWithdraw ETH:\n"
+	ERC20Prefix   = "\x10Withdraw ERC20:\n"
+	ERC721Prefix  = "\x11Withdraw ERC721:\n"
+	ERC721XPrefix = "\x12Withdraw ERC721X:\n"
 )
 
 var ErrTxFailed = errors.New("tx failed")


### PR DESCRIPTION
As per the ToB audit, https://github.com/loomnetwork/transfer-gateway-v2/pull/101/commits/0e9cd20f795566a67497e30307837c526fd00b0b

Message prefixes now have the proper length parameter.