### PR TITLE
Fix TronSigner.Sign()

### DIFF
--- a/auth/tron-signer.go
+++ b/auth/tron-signer.go
@@ -33,7 +33,7 @@ func (k *TronSigner) Sign(txBytes []byte) []byte {
 	signature, err := evmcompat.GenerateTypedSig(
 		sha3.SoliditySHA3(
 			sha3.String("\x19TRON Signed Message:\n32"),
-			txBytes,
+			sha3.SoliditySHA3(txBytes),
 		),
 		k.PrivateKey,
 		evmcompat.SignatureType_TRON,


### PR DESCRIPTION
- Apply hash of tx message before signing