### PR TITLE
Switch back to certusone/yubihsm-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ deps:
 		github.com/stretchr/testify/assert \
 		github.com/go-kit/kit/log \
 		github.com/pkg/errors \
+		github.com/certusone/yubihsm-go \
 		github.com/btcsuite/btcd
 	dep ensure -vendor-only
 	cd $(GOGO_PROTOBUF_DIR) && git checkout v1.1.1
@@ -129,7 +130,7 @@ deps:
 deps-evm: $(SSHA3_DIR) $(GETH_DIR)
 	cd $(GETH_DIR) && git checkout master && git pull && git checkout $(GETH_GIT_REV)
 	go get \
-		github.com/loomnetwork/yubihsm-go \
+		github.com/certusone/yubihsm-go \
 		gopkg.in/check.v1
 
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ HASHICORP_DIR = $(GOPATH)/src/github.com/hashicorp/go-plugin
 GETH_DIR = $(GOPATH)/src/github.com/ethereum/go-ethereum
 SSHA3_DIR = $(GOPATH)/src/github.com/miguelmota/go-solidity-sha3
 BTCD_DIR = $(GOPATH)/src/github.com/btcsuite/btcd
+YUBIHSM_DIR = $(GOPATH)/src/github.com/certusone/yubihsm-go
 # This commit sha should match the one in loomchain repo
 GETH_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 BTCD_GIT_REV = 7d2daa5bfef28c5e282571bc06416516936115ee
+YUBIHSM_REV = 0299fd5d703d2a576125b414abbe172eaec9f65e
 
 .PHONY: all evm examples get_lint update_lint example-cli evmexample-cli example-plugins example-plugins-external plugins proto test lint deps clean test-evm deps-evm deps-all lint
 
@@ -126,6 +128,7 @@ deps:
 	cd $(GOGO_PROTOBUF_DIR) && git checkout v1.1.1
 	cd $(HASHICORP_DIR) && git checkout f4c3476bd38585f9ec669d10ed1686abd52b9961
 	cd $(BTCD_DIR) && git checkout $(BTCD_GIT_REV)
+	cd $(YUBIHSM_DIR) && git checkout master && git pull && git checkout $(YUBIHSM_REV)
 
 deps-evm: $(SSHA3_DIR) $(GETH_DIR)
 	cd $(GETH_DIR) && git checkout master && git pull && git checkout $(GETH_GIT_REV)

--- a/crypto/yubihsm.go
+++ b/crypto/yubihsm.go
@@ -12,12 +12,12 @@ import (
 	"math/rand"
 	"time"
 
+	yubihsm "github.com/certusone/yubihsm-go"
+	"github.com/certusone/yubihsm-go/commands"
+	"github.com/certusone/yubihsm-go/connector"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	loom "github.com/loomnetwork/go-loom"
-	yubihsm "github.com/loomnetwork/yubihsm-go"
-	"github.com/loomnetwork/yubihsm-go/commands"
-	"github.com/loomnetwork/yubihsm-go/connector"
 )
 
 const (


### PR DESCRIPTION
We probably forked `yubihsm-go` because the upstream repo did not support `Secp256k1` but now it does. This PR switches back to the upstream branch since it has a connection issue fix that we need.

Ref: https://github.com/loomnetwork/loomchain/issues/1202