### PR TITLE
Fix Binance Signer

### DIFF
--- a/auth/binance-signer.go
+++ b/auth/binance-signer.go
@@ -5,7 +5,6 @@ package auth
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 
@@ -44,9 +43,8 @@ func NewBinanceSigner(privateKey []byte) *BinanceSigner {
 }
 
 func (s *BinanceSigner) Sign(txBytes []byte) []byte {
-	hash := sha256.Sum256(txBytes)
 	signature, err := evmcompat.GenerateTypedSig(
-		hash[:],
+		evmcompat.GenSHA256(txBytes),
 		s.privateKey,
 		evmcompat.SignatureType_BINANCE,
 	)

--- a/auth/binance-signer.go
+++ b/auth/binance-signer.go
@@ -45,13 +45,15 @@ func NewBinanceSigner(privateKey []byte) *BinanceSigner {
 
 func (s *BinanceSigner) Sign(txBytes []byte) []byte {
 	hash := sha256.Sum256(txBytes)
-	sigBytes, err := secp256k1.Sign(hash[:], crypto.FromECDSA(s.privateKey))
+	signature, err := evmcompat.GenerateTypedSig(
+		hash[:],
+		s.privateKey,
+		evmcompat.SignatureType_BINANCE,
+	)
 	if err != nil {
 		panic(err)
 	}
-
-	typedSig := append(make([]byte, 0, 66), byte(evmcompat.SignatureType_BINANCE))
-	return append(typedSig, sigBytes...)
+	return signature
 }
 
 func (s *BinanceSigner) PublicKey() []byte {

--- a/client/gateway/dappchain_gateway.go
+++ b/client/gateway/dappchain_gateway.go
@@ -165,14 +165,12 @@ func (tg *DAppChainGateway) AddBinanceContractMapping(
 	fromAddr := client.LoomAddressFromBinanceAddress(from)
 	fmt.Printf("Mapping contract %v to %v\n", fromAddr, to)
 
-	hash := ssha.SoliditySHA3(
+	hash := evmcompat.GenSHA256(
 		ssha.Address(from),
 		ssha.Address(common.BytesToAddress(to.Local)),
 	)
 
-	sig, err := evmcompat.GenerateTypedSig(evmcompat.GenSHA256(hash),
-		creator.MainnetPrivKey,
-		evmcompat.SignatureType_BINANCE)
+	sig, err := evmcompat.GenerateTypedSig(hash, creator.MainnetPrivKey, evmcompat.SignatureType_BINANCE)
 	if err != nil {
 		return err
 	}

--- a/client/gateway/dappchain_gateway.go
+++ b/client/gateway/dappchain_gateway.go
@@ -170,7 +170,9 @@ func (tg *DAppChainGateway) AddBinanceContractMapping(
 		ssha.Address(common.BytesToAddress(to.Local)),
 	)
 
-	sig, err := evmcompat.GenerateTypedSig(hash, creator.MainnetPrivKey, evmcompat.SignatureType_BINANCE)
+	sig, err := evmcompat.GenerateTypedSig(evmcompat.GenSHA256(hash),
+		creator.MainnetPrivKey,
+		evmcompat.SignatureType_BINANCE)
 	if err != nil {
 		return err
 	}

--- a/common/evmcompat/helpers.go
+++ b/common/evmcompat/helpers.go
@@ -342,3 +342,8 @@ func PrefixHeader(hash []byte, sigType SignatureType) []byte {
 	}
 	return hash
 }
+
+func GenSHA256(hash []byte) []byte {
+	sum := sha256.Sum256(hash)
+	return sum[:]
+}

--- a/common/evmcompat/helpers.go
+++ b/common/evmcompat/helpers.go
@@ -343,7 +343,12 @@ func PrefixHeader(hash []byte, sigType SignatureType) []byte {
 	return hash
 }
 
-func GenSHA256(hash []byte) []byte {
-	sum := sha256.Sum256(hash)
-	return sum[:]
+// GenSHA256 creates sha256 hash from the concatinated bytes of messages
+func GenSHA256(msgs ...[]byte) []byte {
+	var v []byte
+	for _, msg := range msgs {
+		v = append(v, msg...)
+	}
+	hash := sha256.Sum256(v)
+	return hash[:]
 }

--- a/common/evmcompat/helpers.go
+++ b/common/evmcompat/helpers.go
@@ -152,8 +152,6 @@ func RecoverAddressFromTypedSig(hash []byte, sig []byte, allowedSigTypes []Signa
 			ssha.Bytes32(hash),
 		)
 	case SignatureType_BINANCE:
-		// sum := sha256.Sum256(hash)
-		fmt.Printf("sig: %x\n", sig)
 		return BitcoinRecover(hash, sig[1:])
 	default:
 		return common.Address{}, fmt.Errorf("invalid signature type: %d", sig[0])


### PR DESCRIPTION
- Binance produces signature using secp256k1  instead of solidity
- Modify `GenerateTypedSig` to use secp256k1 for Binance